### PR TITLE
Added generalized input widget for missions

### DIFF
--- a/lib/missions/input.dart
+++ b/lib/missions/input.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+
+// Input widget for missions
+class Input extends StatefulWidget {
+  const Input({Key? key}) : super(key: key);
+
+  @override
+  _InputState createState() => _InputState();
+}
+
+class _InputState extends State<Input> {
+  final TextEditingController textController = new TextEditingController();
+  var inputStr = "";
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+        child: Column(
+      children: [
+        TextField(
+          decoration: InputDecoration(
+            hintText: "Type here",
+          ),
+          onSubmitted: (String str) {
+            setState(() {
+              // Assign the typed str to inputStr
+              inputStr = str;
+            });
+            // Set textController to ""
+            // In essence, removes the typed string from 
+            // the input box when submitted 
+            textController.text = "";
+          },
+          controller: textController,
+        ),
+        // Show submitted String under the input box
+        Text("Your answer: \n" + inputStr),
+      ],
+    ));
+  }
+}


### PR DESCRIPTION
A simple generalized widget for user input to create missions that include a typed answer.

Can be improved and extended